### PR TITLE
Fixed compile error with g++7.4

### DIFF
--- a/MavLinkCom/include/UdpSocket.hpp
+++ b/MavLinkCom/include/UdpSocket.hpp
@@ -2,6 +2,7 @@
 #define MavLinkCom_UdpSocket_hpp
 
 #include <string>
+#include <memory>
 
 namespace mavlinkcom_impl {
     class UdpSocketImpl;


### PR DESCRIPTION
This file raises an error due to `unique_ptr` is not being a member of `std::`.

Adding `#include <memory>` fixes this problem.